### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Introduction
 -------------------
-This dataset contains 124,885,597 million computer generated building footprints in all 50 US states. This data is freely available for download and use.
+This dataset contains 124,885,597 computer generated building footprints in all 50 US states. This data is freely available for download and use.
 
 License
 -------------------


### PR DESCRIPTION
Remove an extraneous word in the README that implies the data set contains 125 trillion footprints.